### PR TITLE
fix 保存後のflashMessageが「システム設定」となっているため、設定値である AddConfig.name が反映されるように調整

### DIFF
--- a/Controller/AddConfigsController.php
+++ b/Controller/AddConfigsController.php
@@ -122,7 +122,7 @@ public $contentName = 'オリジナル設定';
 						// DBに保存
 						if ($this->AddConfig->saveKeyValue($this->request->data)) {
 							$dataSource->commit();
-							$this->setMessage(__d('baser', 'システム設定を保存しました。'));
+							$this->setMessage(__d('baser', $this->contentName . 'を保存しました。'));
 							$this->redirect(['action' => 'form']);
 						}
 					} catch (Exception $ex) {


### PR DESCRIPTION
ちょっとした文言変更だけですが、良かったら取り込み検討お願いします。
